### PR TITLE
Adapt AutoBanner.py to be used with banner.bat

### DIFF
--- a/AutoBanner.py
+++ b/AutoBanner.py
@@ -1,7 +1,6 @@
 import os
 import time
 import ctypes
-import shutil
 import sys
 
 start = True

--- a/AutoBanner.py
+++ b/AutoBanner.py
@@ -38,7 +38,7 @@ while start:
     os.startfile('tools\Ohana3DS.exe')
     os.system('cls')
     print 'Automation in progress please wait....'
-    time.sleep(5)
+    time.sleep(3)
 
     #mouse pos to texture tab and then click x2
     ctypes.windll.user32.SetCursorPos(295, 180)
@@ -119,11 +119,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -150,11 +150,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -181,11 +181,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -212,11 +212,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -243,11 +243,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -274,11 +274,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -305,7 +305,7 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
@@ -336,11 +336,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -367,11 +367,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -398,11 +398,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -429,11 +429,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
@@ -460,11 +460,11 @@ while start:
     time.sleep(0.5)
 
     exec paste
-    time.sleep(1)
+    time.sleep(1.5)
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     os.system("TASKKILL /F /IM Ohana3DS.exe")
     os.system('cls')

--- a/AutoBanner.py
+++ b/AutoBanner.py
@@ -6,14 +6,6 @@ import sys
 
 start = True
 while start:
-    if os.path.exists("banner/backup"):
-        shutil.move("banner/backup", "1")
-        shutil.rmtree("banner")
-        shutil.move("1", "banner")
-
-    if not os.path.exists("banner/backup"):
-        shutil.copytree("banner", "banner/backup")
-    
     retry = True
     while retry:
         #title = raw_input('type in your games folder name found from output/ then press enter:\n')

--- a/AutoBanner.py
+++ b/AutoBanner.py
@@ -2,6 +2,7 @@ import os
 import time
 import ctypes
 import shutil
+import sys
 
 start = True
 while start:
@@ -15,7 +16,8 @@ while start:
     
     retry = True
     while retry:
-        title = raw_input('type in your games folder name found from output/ then press enter:\n')
+        #title = raw_input('type in your games folder name found from output/ then press enter:\n')
+        title = sys.argv[1]
         if os.path.exists("output/"+title):
             os.system('cls')
             print "output/"+title+" folder found"
@@ -39,8 +41,8 @@ while start:
     Lclick = 'ctypes.windll.user32.mouse_event(2, 0, 0, 0,0), ctypes.windll.user32.mouse_event(4, 0, 0, 0,0)'
 
     #open ohana
-    print 'Please wait whilst the banner work is being completed\nJust sit back and let me do the hard work ;)'
-    raw_input('Press Enter to continue....')
+    print 'Please wait whilst the banner work is being completed\nJust sit back, do not touch anything and let me do the hard work ;)'
+    raw_input('Press Enter to continue...')
     os.startfile('tools\Ohana3DS.exe')
     os.system('cls')
     print 'Automation in progress please wait....'
@@ -509,8 +511,4 @@ while start:
     os.system('tools\\3dstool -c -f "output\\' + title + '\\banner.bin" -t banner --banner-dir banner')
     print 'banner.bin file created inside output/'+title+'/banner.bin'
     print 'AutoBanner complete'
-    restart = raw_input("Do you want to restart the program, type 'yes' or 'no'\n")
-    if restart == "no":
-      start = False
-    elif restart == "yes":
-      os.system('cls')
+    start = False

--- a/AutoBanner.py
+++ b/AutoBanner.py
@@ -309,42 +309,11 @@ while start:
 
     exec saveB
     exec Lclick
-    time.sleep(0.5)
+    time.sleep(1)
 
     exec openB
     exec Lclick
     Clb(cwd + "\\banner\\banner8.bcmdl")
-    time.sleep(0.5)
-
-    exec paste
-    time.sleep(0.5)
-
-    exec importB
-    exec Lclick
-    Clb(cwd + "\\output\\" + title + "\\USA_EN2.png")
-    time.sleep(0.5)
-
-    exec paste
-    time.sleep(0.5)
-
-    #mouse pos to EUR_EN3 and then import
-    ctypes.windll.user32.SetCursorPos(350, 140)
-    exec Lclick
-    exec importB
-    exec Lclick
-    Clb(cwd + "\\output\\" + title + "\\EUR_EN3.png")
-    time.sleep(0.5)
-
-    exec paste
-    time.sleep(1)
-
-    exec saveB
-    exec Lclick
-    time.sleep(0.5)
-
-    exec openB
-    exec Lclick
-    Clb(cwd + "\\banner\\banner9.bcmdl")
     time.sleep(0.5)
 
     exec paste


### PR DESCRIPTION
I've changed banner.bat to use AutoBanner.py if present, and if python is installed.
These commits make it compatible with my changes, and also fixes some timing issues.

Banner.bat will pass the game's title to AutoBanner.py, so there's no need to type it again.

If AutoBanner.py is not found or python is not installed, banner.bat will prompt you to open Ohana3DS to manually create the banner instead.
